### PR TITLE
Fixes Bug: Search Navigation Issue

### DIFF
--- a/lib/ListingsPage.dart
+++ b/lib/ListingsPage.dart
@@ -108,7 +108,7 @@ class ListingsPageState extends State<ListingsPage> {
                         _saveSearch(value);
                         _handleSearch(value);
                       }
-                      else{
+                      if(value.isEmpty || value.trim() == ''){
                         _decorationLabelText = 'Search Address';
                         _showSnackbar("Search Bar Cleared.");
                         _handleSearch('');

--- a/lib/ListingsPage.dart
+++ b/lib/ListingsPage.dart
@@ -27,7 +27,7 @@ class ListingsPageState extends State<ListingsPage> {
   ListingsModel listingsModel = ListingsModel();
 
   String _searchQuery = '';
-  String _searchHistoryQuery = '';
+  String _decorationLabelText = 'Search Address';
 
   @override
   void didChangeDependencies() {
@@ -37,7 +37,7 @@ class ListingsPageState extends State<ListingsPage> {
     if(searchQuery != null){
       setState((){
         _searchQuery = searchQuery;
-        _searchHistoryQuery = searchQuery;
+        _decorationLabelText = searchQuery;
         _handleSearch(searchQuery);
       });
     }
@@ -92,22 +92,32 @@ class ListingsPageState extends State<ListingsPage> {
                 const SizedBox(width: 55),
                 Expanded(
                   child: TextField(
-                    onChanged: (value) {
-                      if (value.isNotEmpty) {
-                        _handleSearch(value);
-                      } else {
-                        setState(() {});
-                      }
-                    },
+                    // Removed on account of the onSubmitted() being useless otherwise.
+                    // To re-add, just uncomment below and comment out _handleSearch in onSubmitted below.
+                    // onChanged: (value) {
+                    //   if (value.isNotEmpty) {
+                    //     _handleSearch(value);
+                    //   } else {
+                    //     setState(() {});
+                    //   }
+                    // },
                     onSubmitted: (value) {
                       if (value.isNotEmpty) {
+                        _decorationLabelText = value;
                         _showSnackbar("Search results updated for: $value");
                         _saveSearch(value);
+                        _handleSearch(value);
+                      }
+                      else{
+                        _decorationLabelText = 'Search Address';
+                        _showSnackbar("Search Bar Cleared.");
+                        _handleSearch('');
                       }
                     },
                     decoration: InputDecoration(
                       prefixIcon: const Icon(Icons.search),
-                      labelText: (_searchQuery == '' ? 'Search Address' : _searchHistoryQuery),
+                      labelText: _decorationLabelText,
+                      // labelText: 'Search Address',
                       border: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(30.0),
                       ),

--- a/lib/ListingsPage.dart
+++ b/lib/ListingsPage.dart
@@ -108,7 +108,7 @@ class ListingsPageState extends State<ListingsPage> {
                         _saveSearch(value);
                         _handleSearch(value);
                       }
-                      if(value.isEmpty || value.trim() == ''){
+                      if(value.trim().isEmpty){
                         _decorationLabelText = 'Search Address';
                         _showSnackbar("Search Bar Cleared.");
                         _handleSearch('');


### PR DESCRIPTION
- Removes the search bar feature onChanged so the searched listings only change when hitting enter. **If that feature was very much wanted please request a revise to this PR and I will fix it. I kinda liked the search on changed and if others did too I don't want to remove a cool feature for the sake of bug fixing and cooler label decorations.**
- Search bar properly clears when submitting an empty search. This includes searches consisting of only whitespace, such as spaces or tabs.